### PR TITLE
Fix dropdown placement issue

### DIFF
--- a/packages/navbar/src/styles/navbarStyles.ts
+++ b/packages/navbar/src/styles/navbarStyles.ts
@@ -24,6 +24,7 @@ export const navbarStyles = makeStyles((theme: Theme) => ({
       textDecoration: "none",
       color: theme.palette.primary.main,
     },
+    position: "relative",
   },
 
   // Desktop nav
@@ -40,6 +41,8 @@ export const navbarStyles = makeStyles((theme: Theme) => ({
     height: navHeight,
     margin: "0px",
     padding: "0px",
+    position: "absolute",
+    zIndex: theme.zIndex.tooltip,
   },
   desktopNavItemRoot: {
     display: "flex",


### PR DESCRIPTION
This PR fixes the z-index issue that is caused by using `Popper` with the `disablePortal` prop set to `true`. This causes the popper element to be placed inside the navbar container, which itself has no `z-index` value as it has no `position` CSS attribute. The exact visual issue is highlighted below. 

![dropdown-issue](https://user-images.githubusercontent.com/25919063/155815251-a21e26c1-ee90-4875-8947-4d786aa11564.png)
